### PR TITLE
feat: Add branch name validation with pre-push hook

### DIFF
--- a/.github/workflows/enforce-branch-names.yml
+++ b/.github/workflows/enforce-branch-names.yml
@@ -1,0 +1,20 @@
+name: Enforce Branch Name
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch name
+        run: |
+          if [[ ! "${GITHUB_HEAD_REF}" =~ ^(feature|fix|hotfix|release)\/[a-z0-9._-]+$ ]]; then
+            echo "❌ Branch name '${GITHUB_HEAD_REF}' is invalid."
+            echo "Allowed: feature/*, fix/*, hotfix/*, release/*"
+            exit 1
+          fi
+          
+          echo "✅ Branch name '${GITHUB_HEAD_REF}' is valid."

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Validate branch name before pushing
+echo "🔍 Validating branch name..."
+node scripts/validate-branch-name.js

--- a/README.md
+++ b/README.md
@@ -106,6 +106,28 @@ pnpm install
 git checkout -b feature/my-feature
 ```
 
+### Branch Naming Rules
+
+We enforce consistent branch naming to maintain project organization. All branches must follow this pattern:
+
+**Format:** `^(feature|fix|hotfix|release)\/[a-z0-9._-]+$`
+
+**Valid examples:**
+- `feature/user-authentication`
+- `fix/login-bug`
+- `hotfix/security-patch`
+- `release/v1.2.0`
+
+**Rules:**
+- Must start with: `feature/`, `fix/`, `hotfix/`, or `release/`
+- Use lowercase letters, numbers, dots, underscores, or hyphens only
+- No spaces or uppercase letters allowed
+
+The project includes automatic validation:
+- **Local validation:** Pre-push hook prevents invalid branch names
+- **Remote validation:** GitHub Actions validates PR branch names
+- **Manual check:** Run `npm run validate:branch` anytime
+
 ### Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "format:check": "prettier --check src/**/*.ts",
     "check:version": "node scripts/check-version.js",
     "sync:version": "node scripts/version-sync.js",
+    "validate:branch": "node scripts/validate-branch-name.js",
     "prepare": "husky"
   },
   "keywords": [

--- a/scripts/validate-branch-name.js
+++ b/scripts/validate-branch-name.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * Branch name validation script
+ * Validates that branch names follow the required pattern:
+ * - Must start with: feature/, fix/, hotfix/, or release/
+ * - Followed by lowercase letters, numbers, dots, underscores, or hyphens
+ * - Pattern: ^(feature|fix|hotfix|release)\/[a-z0-9._-]+$
+ */
+
+const { execSync } = require('child_process');
+
+function getCurrentBranch() {
+  try {
+    return execSync('git branch --show-current', { encoding: 'utf8' }).trim();
+  } catch (error) {
+    console.error('❌ Error getting current branch:', error.message);
+    process.exit(1);
+  }
+}
+
+function validateBranchName(branchName) {
+  // Skip validation for main/master branches
+  if (branchName === 'main' || branchName === 'master') {
+    return { valid: true, message: 'Main branch - skipping validation' };
+  }
+
+  // Check if branch name matches the required pattern
+  const pattern = /^(feature|fix|hotfix|release)\/[a-z0-9._-]+$/;
+  
+  if (!pattern.test(branchName)) {
+    return {
+      valid: false,
+      message: `Branch name '${branchName}' is invalid.\n` +
+               `Allowed patterns:\n` +
+               `  • feature/description (e.g., feature/user-authentication)\n` +
+               `  • fix/description (e.g., fix/login-bug)\n` +
+               `  • hotfix/description (e.g., hotfix/security-patch)\n` +
+               `  • release/version (e.g., release/v1.2.0)\n\n` +
+               `Rules:\n` +
+               `  • Use lowercase letters, numbers, dots, underscores, or hyphens\n` +
+               `  • No spaces or uppercase letters allowed`
+    };
+  }
+
+  return { valid: true, message: `Branch name '${branchName}' is valid.` };
+}
+
+function main() {
+  const branchName = getCurrentBranch();
+  const validation = validateBranchName(branchName);
+
+  if (validation.valid) {
+    console.log(`✅ ${validation.message}`);
+    process.exit(0);
+  } else {
+    console.error(`❌ ${validation.message}`);
+    process.exit(1);
+  }
+}
+
+// Run if called directly
+if (require.main === module) {
+  main();
+}
+
+module.exports = { validateBranchName, getCurrentBranch };


### PR DESCRIPTION
## Description
This PR adds branch name validation to enforce consistent naming conventions across the project. It prevents incorrectly named branches from being pushed locally and merged via PRs.

## Changes
- Add GitHub Actions workflow to validate branch names on PRs
- Add pre-push Git hook for local validation using Husky
- Add validation script with clear error messages
- Add `npm run validate:branch` command for manual validation

## Branch Naming Rules
Branch names must follow the pattern: `^(feature|fix|hotfix|release)\/[a-z0-9._-]+$`

### Valid examples:
- `feature/user-authentication`
- `fix/login-bug`
- `hotfix/security-patch`
- `release/v1.2.0`

## Testing
- [x] Valid branch names pass validation
- [x] Invalid branch names are rejected with helpful messages
- [x] Pre-push hook runs automatically
- [x] GitHub workflow validates PR branch names
- [x] Main branch is excluded from validation

## Breaking Changes
None. This only adds validation for new branches.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally
- [x] Documentation updated