### PR TITLE
fix: workflow version detection and pre-push hook script path

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           # Get commits since last tag
           lastTag=${{ env.latestTag }}
-          commits=$(git log --pretty=format:"%s" ${lastTag}..HEAD)
+          commits=$(git log --pretty=format:"%s%n%b" ${lastTag}..HEAD)
           
           # Get current package.json version
           currentVersion=$(node -p "require('./package.json').version")

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,4 +3,4 @@
 
 # Validate branch name before pushing
 echo "🔍 Validating branch name..."
-node scripts/validate-branch-name.js
+ts-node scripts/validate-branch-name.ts


### PR DESCRIPTION
## Description
This PR fixes the automated versioning workflow to properly detect breaking changes and ensure correct version bumps. It also resolves the pre-push hook issue that was preventing branch pushes due to missing JavaScript files.

## Changes
- Fix GitHub Actions workflow to analyze commit bodies for `BREAKING CHANGE` detection
- Update pre-push hook to use TypeScript script instead of missing JavaScript file
- Add proper breaking change commit format for v1.0.0 release
- Ensure workflow can detect major version bumps correctly

## Problem Solved
The workflow was only checking commit subject lines (`%s`) but missing `BREAKING CHANGE` keywords in commit bodies (`%b`). This caused the workflow to publish v0.4.0 instead of v1.0.0 for breaking changes.

### Before:
```yaml
commits=$(git log --pretty=format:"%s" ${lastTag}..HEAD)
```

### After:
```yaml
commits=$(git log --pretty=format:"%s%n%b" ${lastTag}..HEAD)
```

## Pre-push Hook Fix
Updated the pre-push hook to use the correct TypeScript script:
- **Before**: `node scripts/validate-branch-name.js` (file didn't exist)
- **After**: `ts-node scripts/validate-branch-name.ts` (correct TypeScript file)

## Testing
- [x] Workflow now analyzes both commit subjects and bodies
- [x] Pre-push hook runs successfully with TypeScript scripts
- [x] Breaking change detection works for major version bumps
- [x] Branch validation passes for fix branch naming convention

## Breaking Changes
None. This only fixes the versioning workflow and pre-push hook functionality.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Pre-push hook validation passes
- [x] Workflow changes tested and verified
- [x] Branch naming follows project conventions